### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Flask==1.1.1
 Flask-Cors==3.0.7
 Flask-Sockets==0.2.1
 gevent==1.4.0
-git+git://github.com/OpenMined/PySyft@master
+syft==0.2.5
 gunicorn==19.9.0
 itsdangerous==1.1.0
 Jinja2==2.10.1


### PR DESCRIPTION
I suggest to remove git requirement because is quite inestable. Actuallly, if we take the last commit from syft some test related with private tensor fails due to this PR [https://github.com/OpenMined/PySyft/pull/3446](https://github.com/OpenMined/PySyft/pull/3446)

Fixed using syft==0.2.5

