### PR TITLE
fixes state_ids error when using PySyft v0.2.5.

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -220,8 +220,8 @@ def search_encrypted_models():
 
             workers = set()
             # Check every state used by this plan
-            for state_id in model.state.state_ids:
-                obj = local_worker._objects.get(state_id)
+            for state_id in model.state.state_placeholders:
+                obj = local_worker._objects.get(state_id.id.value)
                 # Decrease in Tensor Hierarchy (we want be a AdditiveSharingTensor to recover workers/crypto_provider addresses)
                 while not isinstance(obj, sy.AdditiveSharingTensor):
                     obj = obj.child


### PR DESCRIPTION
It fixes the following error:
AttributeError: 'State' object has no attribute 'state_ids'
when trying to run a remote inference.

refs #https://github.com/OpenMined/PyGrid/issues/543

# Pull Request

## Description
Please include a summary of the change and which issue is fixed. If this closes one or more open issues, [please tag them as described here](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Affected Dependencies
List any dependencies that are required for this change.

## Type of Change
Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change which adds documentation)
- [ ] Improvement (non-breaking change that improves the performance or reliability of existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I did follow the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md)
- [ ] I did follow the [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have added tests for my changes

## Additional Context
Please also include relevant motivation and context.
